### PR TITLE
Pushes updated version in bower.json in bump task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,6 +94,7 @@ module.exports = function(grunt) {
     bump: {
       options: {
         files: ['package.json', 'bower.json'],
+        commitFiles: ['package.json', 'bower.json'],
         pushTo: "origin"
       }
     },


### PR DESCRIPTION
Quick hotfix - wasn't committing the updated `bower.json` version as part of the bump task.
