### PR TITLE
NPM Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "ds-neue",
   "version": "2.8.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DoSomething/ds-neue.git"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",


### PR DESCRIPTION
Adds Grunt dependencies to NPM Adds a handful of plug-ins to Grunt along with a new "repository" field to close #99.
