### PR TITLE
Public dir: assets => dist

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,7 +2,7 @@ require 'sinatra'
 require 'sinatra/content_for'
 require 'kss'
 
-set :public_folder, Proc.new { File.join(root, "assets") }
+set :public_folder, Proc.new { File.join(root, "dist") }
 
 get '/' do
   @styleguide = Kss::Parser.new('scss/')


### PR DESCRIPTION
Updates Sinatra's default public directory from `assets` to `dist` to fix #101
