### PR TITLE
Requiring minimum jQuery 1.7 for .on() API.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     ".scss-lint.yaml"
   ],
   "dependencies": {
-    "jquery": "1.10.2"
+    "jquery": ">=1.7.2"
   }
 }


### PR DESCRIPTION
Fixes #107. :cake: 
