### PR TITLE
Fixed typo in desktop media query.

### DIFF
--- a/scss/globals/_grid-settings.scss
+++ b/scss/globals/_grid-settings.scss
@@ -10,7 +10,7 @@ $grid-columns: 6; // mobile first, dude
 
 // Breakpoints:
 $tablet: new-breakpoint(min-width 768px 12); // 12 columns
-$desktop: new-breakpoint(max-width 1080px 12); // 12 columns
+$desktop: new-breakpoint(min-width 1080px 12); // 12 columns
 
 // Development
 $visual-grid: true;


### PR DESCRIPTION
![writing css](https://f.cloud.github.com/assets/583202/2138427/e1892f64-9333-11e3-95c9-693605905c52.gif)

Fixes #129.
