### PR TITLE
Fixed Firefox display issue with Flexbox.

### DIFF
--- a/scss/_main/_layout.scss
+++ b/scss/_main/_layout.scss
@@ -4,23 +4,18 @@
 // Styleguide X.X
 .wrapper {
   @include outer-container-margin;
-  -webkit-box-flex: 1;
-  -webkit-flex: 1;
-  -moz-box-flex: 1;
-  -ms-flex: 1;
   flex: 1;
 }
 
 body {
   // flexbox stuff to keep footer at bottom
-  display: -webkit-flex;
   display: flex;
-  @include prefixer(flex-direction, column, webkit ms);
+  flex-direction: column;
   min-height: 100%;
 }
 
 // Basic wrapper for text content. Centers on grid and adds proper margin
-// for floating header. 
+// for floating header.
 //
 // Styleguide X.X
 .page {


### PR DESCRIPTION
For whatever reason, removing vendor-prefixed flexbox code seems to fix Firefox display issue. Sacrifices Safari's flexbox implementation. Fixes #144.

Happy Firefox:
![screen shot 2014-02-20 at 5 36 47 pm](https://f.cloud.github.com/assets/583202/2224497/7f7417e6-9a7f-11e3-8061-2b0a8da142a5.png)

Happy Chrome:
![screen shot 2014-02-20 at 5 36 59 pm](https://f.cloud.github.com/assets/583202/2224500/8706c9d6-9a7f-11e3-99d8-09850d6a6b1e.png)

Indifferent Safari:
![screen shot 2014-02-20 at 5 38 10 pm](https://f.cloud.github.com/assets/583202/2224515/b08dc494-9a7f-11e3-9c4d-a305185f7493.png)
