### PR TITLE
Moves "icomoon-icon" Mixin

### DIFF
--- a/scss/globals/_fonts.scss
+++ b/scss/globals/_fonts.scss
@@ -48,20 +48,6 @@
   font-style: normal;
 }
 
-@mixin icomoon-icon {
-  font-family: 'icomoon';
-  speak: none;
-  font-style: normal;
-  font-weight: normal;
-  font-variant: normal;
-  text-transform: none;
-  line-height: 1;
-
-  // Better Font Rendering
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 .icon-pencil:before {
   @include icomoon-icon;
   content: "\e600";

--- a/scss/globals/_mixins.scss
+++ b/scss/globals/_mixins.scss
@@ -27,3 +27,18 @@
     box-shadow: 0 0 3px $blue;
   }
 }
+
+// Cleaner calling of our icon font
+@mixin icomoon-icon {
+  font-family: 'icomoon';
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+
+  // Better Font Rendering
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}


### PR DESCRIPTION
Moves the mixin from `_fonts.scss` to `_mixins.scss` to allow for its use in paraneue_ds.
