### PR TITLE
Suppresses "expr" warnings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,6 +16,7 @@
     "strict": true,
     "trailing": true,
     "smarttabs": true,
+    "expr": true,
     "predef": [
       "_",
       "$",


### PR DESCRIPTION
Keeps Neue in sync with a [change](https://github.com/DoSomething/dosomething/issues/818) made in the paraneue_ds `.jshintrc` file.
