### PR TITLE
Bumps Ruby version to 2.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '1.9.3'
+ruby '2.1.1'
 
 gem 'sinatra', '~> 1.4.3'
 gem 'sinatra-contrib', '~> 1.4.1'


### PR DESCRIPTION
:warning: This is a breaking change. You will need to update to v2.1.1 after this is merged in. Brings Neue's Gemfile up to date with the latest stable version of Ruby because this is driving me crazy:

![ruby-version](https://f.cloud.github.com/assets/1479130/2350976/0e9b0f72-a577-11e3-900c-de59221e2aa1.png)

Fixes #93 
