### PR TITLE
Footer Background Color Change

### DIFF
--- a/scss/_main/_chrome.scss
+++ b/scss/_main/_chrome.scss
@@ -346,7 +346,7 @@
       border-top: 0;
       margin-top: 1.65rem;
       text-align: left;
-      @include span-columns(5);
+      @include span-columns(7);
     }
 
     li {


### PR DESCRIPTION
# Changes
- sets the global footer background color to black
- increases `.social.tablet` width to fill space left by do something logo

![footer](https://f.cloud.github.com/assets/1479130/2422890/7e6bd31e-ab93-11e3-9c4a-a1ed977f51c8.png)

Fixes DoSomething/dosomething#1197
