### PR TITLE
Sets border-box in neue.css

### DIFF
--- a/scss/_main/_base.scss
+++ b/scss/_main/_base.scss
@@ -1,5 +1,9 @@
-// Base HTML elements
+// Set border-box on all the elements!
+* {
+  @include prefixer(box-sizing, border-box, webkit moz spec);
+}
 
+// Base HTML elements
 html {
   height: 100%;
   font-size: 16px;

--- a/scss/globals/_grid-settings.scss
+++ b/scss/globals/_grid-settings.scss
@@ -1,5 +1,9 @@
 @import "../vendor/neat/neat-helpers";
 
+// We set box-sizing on elements in `base.scss` instead to avoid
+// repeating markup each time we include `helpers.scss`
+$border-box-sizing: false;
+
 // Set up grid measurements (using desktop dimensions to
 // calculate, but they'll get made into percentages).
 $column: 59px;


### PR DESCRIPTION
Rather than generating automatically in `helpers.scss` from Bourbon Neat.

Fixes #194.
