### PR TITLE
Bookmarklets Section

### DIFF
--- a/views/styleguide.erb
+++ b/views/styleguide.erb
@@ -6,6 +6,12 @@
     </section>
 
     <section class="row section styleguide-section">
+
+      <h2 id="bookmarklets">Bookmarklets</h2>
+      <p>We currently have two bookmarklets for <strong>Fender Funtime&#8482;</strong>. To install, drag either to your bookmarks toolbar and click.</p>
+
+      <p><a href="javascript:(function(){jQuery('body').toggleClass('show-visual-grid')})();" class="btn secondary tiny">Toggle Grid</a> toggles a grid overlay on any Neue-powered DoSomething.org website. Or just click to try it out on this page!</p>
+      <p><a class="btn secondary tiny" href="javascript:(function() { jQuery('#admin-menu, .admin--tabs').hide(); jQuery('body').attr('style', 'margin-top: 0 !important;'); })();">Hide Admin</a> hides the admin menu and admin tabs on any of our Drupal properties to purify mobile views for responsive development.</p>
       <h2 id="fonts-and-colors">Fonts &amp; Colors</h2>
 
      <h3>Fonts</h3>
@@ -113,8 +119,7 @@
       <h2 id="layout">Layout</h2>
       <img src="/assets/kss/grid-visualization.jpg" alt="visualization of grid on DoSomething.org homepage" />
       <p>We use <a href="http://neat.bourbon.io">Bourbon Neat</a> to build our interface on a fluid 16-column grid. See the <a href="http://neat.bourbon.io/docs">documentation</a> for implementation details. See <a href="https://github.com/DoSomething/neue/blob/dev/scss/globals/_grid-settings.scss"><code>_grid-settings.scss</code></a> for grid settings and breakpoints.</p>
-      <p>Drag the <a href="javascript:(function(){jQuery('body').toggleClass('show-visual-grid')})();" class="btn secondary tiny">Grid Bookmarklet</a> to your bookmarks toolbar and click to toggle a grid overlay on any Neue-powered DoSomething.org website. Or just click to try it out on this page!</p>
-      <p>Drupal's admin menu giving you a headache when working on lower device resolutions? Drag the <a class="btn secondary tiny" href="javascript:(function() { jQuery('#admin-menu, .admin--tabs').hide(); jQuery('body').attr('style', 'margin-top: 0 !important;'); })();">Hide Admin</a> to your bookmarks toolbar and click to hide the admin menu and admin tabs on any of our Drupal properties.</p>
+      <p class="js-jump-scroll"><small>Psst! We have <a href="#bookmarklets">a bookmarklet</a> to toggle a visualization of Neue's grid.</small></p>
     </section>
 
   <section class="row section styleguide-section">


### PR DESCRIPTION
## Changes
- Adds "Bookmarklets" section above the pattern library's style guide
- Adds a bookmarklet to hide all Drupal admin menus and tabs

![bookmarklets](https://cloud.githubusercontent.com/assets/1479130/2542132/e73aa14a-b5e3-11e3-92ea-55f62a25fbb8.png)
### Notes

This arguably isn't the best place for a collection of bookmarklets as some are application specific. For that reason, this addition should be seen as temporary. We were having trouble adding inline HTML to the production repository's GitHub Wiki page.
