### PR TITLE
Increases Default Gutter Width

### DIFF
--- a/scss/globals/_grid-settings.scss
+++ b/scss/globals/_grid-settings.scss
@@ -6,8 +6,8 @@ $border-box-sizing: false;
 
 // Set up grid measurements (using desktop dimensions to
 // calculate, but they'll get made into percentages).
-$column: 59px;
-$gutter: 16px;
+$column: 60px;
+$gutter: 32px;
 
 // max width beyond which the grid shall not pass
 $max-width: 1200px;


### PR DESCRIPTION
## Changes
- Doubles the grid gutter from `16px` to `32px`
### Description

Bodies of text were sitting uncomfortably close to one another with only a `16px` gutter between them.

References: DoSomething/dosomething/issues/1446
