### PR TITLE
Increase Default Container Width

### DIFF
--- a/scss/globals/_grid-settings.scss
+++ b/scss/globals/_grid-settings.scss
@@ -10,7 +10,7 @@ $column: 59px;
 $gutter: 16px;
 
 // max width beyond which the grid shall not pass
-$max-width: 1200px;
+$max-width: 1440px;
 
 $grid-columns: 8; // mobile first, dude
 


### PR DESCRIPTION
## Changes
- Increases max-width of the layout grid from `1200px` to `1440px`
## Rationale

Our `1200px` max-width is showing default grey background on most laptops. This change allows us to appear full-width for most smaller screen sizes.

Resolves DoSomething/dosomething#676
