### PR TITLE
Header nav sizing

### DIFF
--- a/scss/_main/_chrome.scss
+++ b/scss/_main/_chrome.scss
@@ -99,13 +99,14 @@
         float: left;
         display: block;
         text-align: left;
-        margin: 0 5.59492% 0 0;
+        margin: 0 3.5% 0 0;
         padding: 1.25rem 0;
         border-bottom: 0;
       }
 
       @include media($desktop) {
         padding: 0.75rem 0;
+        margin: 0 5% 0 0;
       }
     }
 
@@ -121,12 +122,12 @@
 
     strong {
       display: block;
-      font-size: 16px;
+      font-size: $font-regular;
     }
 
     span {
       text-transform: uppercase;
-      font-size: 12px;
+      font-size: $font-smaller;
 
       @include media($tablet) {
         display: none;
@@ -190,7 +191,7 @@
       }
 
       @include media($tablet) {
-        width: 100px;
+        width: 110px;
         border: 1px solid $off-black;
         background-color: transparent;
       }


### PR DESCRIPTION
Tablet width:
![screen shot 2014-04-01 at 5 49 35 pm](https://cloud.githubusercontent.com/assets/583202/2585265/010d8222-b9ea-11e3-8930-d18c56fe2368.png)

Desktop width:
![screen shot 2014-04-01 at 5 49 48 pm](https://cloud.githubusercontent.com/assets/583202/2585268/07627254-b9ea-11e3-974c-383809904b95.png)

Adjusts spacing on nav items; adjusts font-size based on new 18px base size. Adds a min-width on logo container to keep spacing comfortable on tablet (downside: breaks first nav item off of the grid).
