### PR TITLE
Remove lint-spaces task.

### DIFF
--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -1,7 +1,7 @@
 module.exports = {
   sass: {
     files: ["scss/**/*.{scss,sass}"],
-    tasks: ["shell:scsslint", "lintspaces:scss", "sass:compile"]
+    tasks: ["shell:scsslint", "sass:compile"]
   },
   js: {
     files: ["js/**/*.js", "tests/**/*.js"],


### PR DESCRIPTION
![evilmaxwell-1389712606](https://cloud.githubusercontent.com/assets/583202/2891406/43e1d612-d532-11e3-8f40-0764ad42713f.png)

Removing `grunt-lint-spaces` task since it was causing errors with JSDoc style comments for functions/mix-ins and `scss-lint` should be handling most indentation linting.
