### PR TITLE
Move people to the new neue.dosomething.org domain.

### DIFF
--- a/assets/kss/styleguide-domain-tip.js
+++ b/assets/kss/styleguide-domain-tip.js
@@ -1,0 +1,22 @@
+/**
+ * Suggests visiting neue.dosomething.org instead of
+ * the old styleguide.dosomething.org!
+ */
+
+$(function () {
+  // If user visits styleguide.dosomething.org, move them:
+  if(window.location.hostname === "styleguide.dosomething.org") {
+    window.location.replace("http://neue.dosomething.org/?redirected=true");
+  }
+
+  // Then tell them of their folly:
+  if(window.location.search === "?redirected=true") {
+    var $warning = $("<div class='messages'>The styleguide has moved! Update your bookmarks to <a href='http://neue.dosomething.org'>neue.dosomething.org</a>.");
+
+    $("body").prepend($warning);
+    $warning.hide();
+    $warning.slideDown();
+
+    NEUE.Messages.attachCloseButton( $warning );
+  }
+});

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -85,6 +85,7 @@
 <script type="text/javascript" src="/neue.js"></script>
 <script type="text/javascript" src="/assets/kss/kss.js"></script>
 <script type="text/javascript" src="/assets/kss/kss-colortiles.js"></script>
+<script type="text/javascript" src="/assets/kss/styleguide-domain-tip.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Redirects people to [neue.dosomething.org](http://neue.dosomething.org/) if they go to the old URL.

(This pull request only affects the style guide.)
