### PR TITLE
Make modal "x" work on light and dark BGs without toggling class.

### DIFF
--- a/scss/_patterns/_forms.scss
+++ b/scss/_patterns/_forms.scss
@@ -399,7 +399,7 @@ select {
   .message-close-button {
     @include close-parent;
 
-    top: 0.4rem;
-    opacity: 0.7; // Match opacity to parent copy style
+    color: #fff;
+    top: 0;
   }
 }

--- a/scss/_patterns/_widgets.scss
+++ b/scss/_patterns/_widgets.scss
@@ -32,6 +32,7 @@
 
     .modal-close-button {
       @include close-parent;
+      color: #aaa;
 
       &.-alt {
         font-size: 1rem;

--- a/scss/globals/_mixins.scss
+++ b/scss/globals/_mixins.scss
@@ -54,19 +54,15 @@
 // modals, dialogs and system status messages
 @mixin close-parent {
   position: absolute;
-  top: 0.5rem; right: 1.5rem;
-  font-size: 2rem;
+  top: 0.25rem; right: 1.5rem;
+  font-size: 2.5rem;
   font-weight: bold;
-  color: #333;
+  color: $dark-gray;
   opacity: 0.5;
   text-decoration: none;
 
   &:hover {
     opacity: 1;
-  }
-
-  &.white {
-    color: #fff;
   }
 }
 


### PR DESCRIPTION
![screen shot 2014-05-19 at 2 05 06 pm](https://cloud.githubusercontent.com/assets/583202/3018003/b5e41ede-df80-11e3-8d51-322f05b0959f.png)
![screen shot 2014-05-19 at 2 05 23 pm](https://cloud.githubusercontent.com/assets/583202/3018004/b7475fac-df80-11e3-890b-7c084d5062ef.png)

Tried out using a light gray (`#ccc`) rather than toggling between dark gray and white. Seems to work pretty well, and means one less thing we need to specify when creating modals. References DoSomething/dosomething#2159.
