### PR TITLE
Add gitignore for GH Pages that leaves Bower components intact.

### DIFF
--- a/.pagesignore
+++ b/.pagesignore
@@ -1,0 +1,33 @@
+# Ignore dependencies
+node_modules
+npm-debug.log
+
+# Vim stuff
+*.swp
+
+# SASS stuff
+.sass-cache
+
+# OS X stuff
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# editor ignores
+*.sublime-workspace
+*.sublime-project
+
+# rack/pow stuff
+log/
+tmp/
+
+
+


### PR DESCRIPTION
Adds another `gitignore` that we'll use in the build process to commit `bower_components` to the `gh-pages` branch.
