### PR TITLE
Fix image URLs for "white" chrome style.

### DIFF
--- a/scss/_main/_chrome.scss
+++ b/scss/_main/_chrome.scss
@@ -54,10 +54,10 @@
       color: #fff;
       border: 1px solid #fff;
       box-shadow: 0 1px 3px rgba(#000, 0.3);
-      background-image: neue-image-url("search_light.png");
+      background-image: url("assets/images/search_light.png");
 
       @include hidpi {
-        background-image: neue-image-url("search_light@2x.png");
+        background-image: url("assets/images/search_light@2x.png");
       }
     }
   }
@@ -234,7 +234,7 @@
       @include transition(width 0.5s);
 
       @include hidpi {
-        background-image: image-url("assets/images/search_dark@2x.png");
+        background-image: url("assets/images/search_dark@2x.png");
       }
 
       @include media($tablet) {


### PR DESCRIPTION
Gross :thumbsdown: 

![screen shot 2014-06-16 at 3 19 56 pm](https://cloud.githubusercontent.com/assets/583202/3292071/41109a1c-f58b-11e3-9860-f4ba5ccd5e0c.png)

vs.

Not gross :thumbsup: 

![screen shot 2014-06-16 at 3 20 10 pm](https://cloud.githubusercontent.com/assets/583202/3292073/43e927b8-f58b-11e3-85b6-aa140532d693.png)
