### PR TITLE
Update to add top margin to h3 following a p tag.

### DIFF
--- a/scss/_patterns/_container.scss
+++ b/scss/_patterns/_container.scss
@@ -134,7 +134,8 @@
 
   // <p> tags following other items.
   p + p,
-  ul + p {
+  ul + p,
+  p + h3 {
     margin-top: 27px;
   }
 


### PR DESCRIPTION
@DFurnes 

Quick addition to add margins to h3's following p tags. Eliminates the need for containing `.__row` div if it's simple content :)
