### PR TITLE
only showing tile descriptions at desktop breakpoint

### DIFF
--- a/scss/_patterns/_tile.scss
+++ b/scss/_patterns/_tile.scss
@@ -131,7 +131,7 @@
 
     @include visually-hidden();
 
-    @include media($tablet) {
+    @include media($desktop) {
       @include visually-restored();
     }
 


### PR DESCRIPTION
Fixes [DS-217](https://jira.dosomething.org/browse/DS-217)

Hides tile descriptions on all breakpoints except desktop to prevent a 'cluttered' UI
