### PR TITLE
reverting tile taglines at tablet breakpoint

### DIFF
--- a/scss/_patterns/_tile.scss
+++ b/scss/_patterns/_tile.scss
@@ -131,7 +131,7 @@
 
     @include visually-hidden();
 
-    @include media($desktop) {
+    @include media($tablet) {
       @include visually-restored();
     }
 


### PR DESCRIPTION
Reverting tile taglines back to original tablet breakpoint until better solution is discussed
