### PR TITLE
DS-312 Prevent form submission if a non-required field fails validation.

### DIFF
--- a/js/validation.js
+++ b/js/validation.js
@@ -248,10 +248,20 @@ define(function(require) {
    */
   $("body").on("submit", "form", function(event, isValidated) {
     var $form = $(this);
-    var $validationFields = $form.find("[data-validate]").filter("[data-validate-required]");
+    var $validationFields = $form.find("[data-validate]");
 
+    // Disable form submission to prevent double-clicks.
     disableFormSubmit($form);
 
+    // We want to validate all [data-validate] field that are either required, or have user input.
+    $validationFields = $validationFields.map(function() {
+      var $this = $(this);
+      if(typeof $this.attr("data-validate-required") !== "undefined" || $this.val() !== "") {
+        return $this;
+      }
+    });
+
+    // If no fields should be validated, submit!
     if($validationFields.length === 0) {
       return true;
     }


### PR DESCRIPTION
## Changes
- Prevents form submission if a filled-in `data-validate` field doesn't validate, even if it's not required. (So, on the registration form for example: phone could be blank and form would submit, but if the user has entered content into that field, it must validate). Previously only required fields blocked form submission.

Relevant JIRA ticket: [DS-312](https://jira.dosomething.org/browse/DS-312)
## How do I test this?

Pull down this branch, drop it in your `bower_components/neue` directory in the main app, and take it for a spin. You should still be able to register without a phone number, but anything that fails validation on that field should now prevent form submission.
