### PR TITLE
adding new duo and triad gallery patterns

### DIFF
--- a/scss/_patterns/_gallery.scss
+++ b/scss/_patterns/_gallery.scss
@@ -3,7 +3,7 @@
 //
 // .-mosaic - Tiles are arranged without spacing next to each other.
 //
-// Styleguide 4.8.1 - Gallery
+// Styleguide 4.8.1 - Mosaic
 
 .gallery {
   list-style-type: none;
@@ -128,9 +128,12 @@
     }
   }
 
-  // Three columned gallery.  Defaults using images with same dimensions.
+  // Triad Gallery.  Defaults to using images with same dimensions.
   //
-  // .-aligned - Tiles are with image flushed to top and minimum height to force content below to line up with adjacent tiles since image dimensions can vary.  Defaults to 75px tall.  This should be overriden when necessary.  
+  // .-aligned - Tiles with image flushed to top and minimum
+  // height to force content below to line up with adjacent tiles
+  // since image dimensions can vary.  Defaults to 75px tall.  
+  // This should be overridden when necessary.  
   //
   // Styleguide 4.8.2 - Triad
   &.-triad {
@@ -161,7 +164,7 @@
     }
   }
 
-  // Two columned gallery with image in left column and content in right column.
+  // Duo Gallery with image in left column and content in right column.
   //
   // Styleguide 4.8.3 - Duo
   &.-duo {

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -268,7 +268,7 @@
   <% end %>
 
   <h4 id="gallery">4.8 Gallery</h4>
-  <% styleguide_block  '4.8.1 - Gallery' do %>
+  <% styleguide_block  '4.8.1 - Mosaic' do %>
     <ul class="gallery -mosaic">
       <li>
         <article class="tile tile--campaign">


### PR DESCRIPTION
# What's in this PR
- New 'duo' gallery pattern
  ![image](https://cloud.githubusercontent.com/assets/1566749/4153299/1e9649cc-3457-11e4-9bfc-8ab2eac1a63d.png)
  ![image](https://cloud.githubusercontent.com/assets/1566749/4153308/383c430e-3457-11e4-8559-082213a6af1e.png)
- Updated 'triad' gallery pattern with 'aligned' modifier
  ![image](https://cloud.githubusercontent.com/assets/1566749/4153257/9d908d38-3456-11e4-9d33-4be1fb059b9a.png)
  ![image](https://cloud.githubusercontent.com/assets/1566749/4153288/fe77b176-3456-11e4-8be9-498c18a10010.png)
