### PR TITLE
removes whitespace below a gallery that is a direct child of the last .container

### DIFF
--- a/scss/_patterns/_container.scss
+++ b/scss/_patterns/_container.scss
@@ -41,6 +41,13 @@
     }
   }
 
+  // removes bottom padding on a gallery that is a direct child of the last .container
+  &:last-of-type {
+    > .gallery {
+      padding-bottom: 0;
+    }
+  }
+
   .-columned {
     @include media($tablet) {
       @include span-columns(6 of 12);


### PR DESCRIPTION
Removes bottom padding on a gallery that is a direct child of the last .container:

![image](https://cloud.githubusercontent.com/assets/1566749/4292290/0f0f511e-3dcc-11e4-9e20-1a7c3ae52cd1.png)

Resolves [DS-400](https://jira.dosomething.org/browse/DS-400)
