### PR TITLE
Only constrain height of logo.

### DIFF
--- a/scss/_main/_chrome.scss
+++ b/scss/_main/_chrome.scss
@@ -102,7 +102,6 @@
     }
 
     img {
-      width: 80px;
       height: 70px;
     }
   }


### PR DESCRIPTION
# Changes
- Only constrain the height of the logo in the site chrome. Allows more flexibility with alternate (international?) logos, with no visual change for the standard logo.
