### PR TITLE
superscript inline with copy

### DIFF
--- a/scss/_patterns/_inline.scss
+++ b/scss/_patterns/_inline.scss
@@ -15,6 +15,11 @@
     margin: 0;
   }
 
+  sup {
+    top: 0;
+    width: 18px;
+  }
+
   a {
     color: $med-gray;
 


### PR DESCRIPTION
Moves superscripts with legal copy to be inline with content

Resolves [1790](https://github.com/DoSomething/dosomething/issues/1790)
