### PR TITLE
added default line height to accomodate multiple lines

### DIFF
--- a/scss/_patterns/_forms.scss
+++ b/scss/_patterns/_forms.scss
@@ -118,7 +118,8 @@ textarea {
   background: $blue;
   border: 0;
   margin: 4px 0;
-  padding: 0.5em 1em 0.4em;
+  line-height: 1.3;
+  padding: 0.55em 1em 0.45em;
   cursor: pointer;
   color: #fff;
   font-family: $font-proxima-nova;


### PR DESCRIPTION
Adds default line height to form buttons to accommodate for multiple lines.  Padding was tweaked to maintain vertical spacing. 

Resolves [1540](https://github.com/DoSomething/dosomething/issues/1540)
