### PR TITLE
Make messages look better when located outside of site chrome.

### DIFF
--- a/scss/_patterns/_forms.scss
+++ b/scss/_patterns/_forms.scss
@@ -311,9 +311,10 @@ label.option {
 .messages {
   position: relative;
   width: 100%;
+  max-width: $max-width;
   background: $purple;
   text-align: left;
-  margin: 0;
+  margin: 0 auto;
   padding: 18px 72px 18px 27px;
   @include rgba(color, #fff, 0.7);
 


### PR DESCRIPTION
# Changes
- Make messages look better when located outside of site chrome, by setting a max-width and centering them in the viewport.
# Screenshots
#### Before

![screen shot 2014-09-24 at 10 45 55 am](https://cloud.githubusercontent.com/assets/583202/4389958/8ffee950-43f9-11e4-871e-c5faa35a147f.png)
#### After

![screen shot 2014-09-24 at 10 45 39 am](https://cloud.githubusercontent.com/assets/583202/4389956/8dcba9e8-43f9-11e4-88b2-1ae16ccdc2b2.png)
