### PR TITLE
Modal bug squashing

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -85,7 +85,7 @@ define(function(require) {
 
     // If modal markup isn't initialized, save and display once it is.
     if(!modalReady) {
-      queuedModal = {'$el': $el, 'options': options};
+      queuedModal = {"$el": $el, "options": options};
       return false;
     }
 


### PR DESCRIPTION
# Changes
- Fixes issue where an empty overlay would be shown in `NEUE.Modal.open()` was called with a non-existant selector.
- Fixes an issue where a programmatically shown modal would not appear if modal container was not fully initialized. We now save a "queued" modal if `NEUE.Modal.open()` is called before the module is fully initialized.

For review: @DoSomething/front-end 
