### PR TITLE
Allow videos to fit comfortably inside tiles.

### DIFF
--- a/scss/_modules/_tile.scss
+++ b/scss/_modules/_tile.scss
@@ -73,6 +73,11 @@
     }
   }
 
+  video {
+    width: 100%;
+    height: auto;
+  }
+
   img {
     display: block;
     width: 100%;

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -466,6 +466,7 @@
             <p class="__tagline">According to the latest research, kittens will outlive the human species after the apocalypse.</p>
           </div>
           <img alt="kitten overlords" src="http://placekitten.com/g/600/600" />
+          <!-- <video src="source.mp4" width="1080" height="1080" poster="poster.png" autoplay loop></video> -->
         </a>
       </article>
     <% end %>


### PR DESCRIPTION
# Changes
- Making sure `<video>` is nice and comfortable when placed inside a `.tile--campaign`.
- Adds some (commented out) example video markup to the style guide.

:movie_camera: :boom: 
