### PR TITLE
Adding height: auto to fix image sizing bug

### DIFF
--- a/scss/_modules/_media.scss
+++ b/scss/_modules/_media.scss
@@ -31,5 +31,9 @@
 
   .__description {
     line-height: 1.2;
+    
+    p {
+      margin: 0;
+    }
   }
 }


### PR DESCRIPTION
@DFurnes @weerd I had to add height: auto to to the image in this pattern because the image markup we use to populate this sets height and width attributes on the img tag. It was causing the image to keep the height set in that tag instead of resizing appropriately. 

Such a small PR! would you normally release something like this or wait until more changes happen?
