### PR TITLE
Adding margin to h2 tags after ul tags

### DIFF
--- a/scss/_regions/_container.scss
+++ b/scss/_regions/_container.scss
@@ -81,6 +81,12 @@
   p + .tabbed {
     margin-top: 27px;
   }
+
+  // Fixes spacing between ul and h2.
+  // @TODO: Remove after typography revamp.
+  ul + h2 {
+    margin-top: 1em;
+  }
 }
 
 


### PR DESCRIPTION
Fixes DoSomething/dosomething#3542 . We fixed for modals but were seeing the same issue on taxonomy pages. I added a note to include this in typography refactor. @DFurnes @weerd 
