### PR TITLE
Add "modernizr-" prefix to Modernizr classes.

### DIFF
--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -171,7 +171,7 @@
   background-size: 18px 18px;
   appearance: none;
 
-  .no-svg & {
+  .modernizr-no-svg & {
     background-image: neue-asset-url("images/fallbacks/search.png");
   }
 
@@ -179,7 +179,7 @@
     background-image: neue-asset-url("images/spinner.svg");
   }
 
-  .no-smil &.loading {
+  .modernizr-no-smil &.loading {
     background-image: neue-asset-url("images/fallbacks/spinner16.gif");
   }
 }
@@ -334,7 +334,7 @@ textarea.text-field {
   }
 }
 
-.checked.label-click .option {
+.modernizr-checked.modernizr-label-click .option {
   overflow: hidden;
 
   // Hat tip to Mark Otto's [WTF, Forms](http://wtfforms.com)

--- a/scss/_components/_button.scss
+++ b/scss/_components/_button.scss
@@ -129,12 +129,12 @@
       background-size: 32px;
     }
 
-    .no-smil &, .no-smil &:hover, .no-smil &:active {
+    .modernizr-no-smil &, .modernizr-no-smil &:hover, .modernizr-no-smil &:active {
       // If no support for animated SVG, use 32px animated gif.
       background-image: neue-asset-url("images/fallbacks/spinner.gif");
     }
 
-    .no-rgba &, .no-rgba &:hover, .no-rgba &:active {
+    .modernizr-no-rgba &, .modernizr-no-rgba &:hover, .modernizr-no-rgba &:active {
       // If no support for text color:transparent, hide image and lighten text.
       color: $light-gray;
       background-image: none;

--- a/scss/_components/_spinner.scss
+++ b/scss/_components/_spinner.scss
@@ -7,7 +7,7 @@
   height: 32px;
   width: 32px;
 
-  .no-smil & {
+  .modernizr-no-smil & {
     background-image: neue-asset-url("images/fallbacks/spinner.gif");
   }
 }

--- a/scss/_components/_tabs.scss
+++ b/scss/_components/_tabs.scss
@@ -32,7 +32,7 @@
 
 
 // We add interactive elements once we know JS is working.
-.js {
+.modernizr-js {
   .tabs {
     > .wrapper {
       @include visually-hidden();

--- a/scss/_modules/_tile.scss
+++ b/scss/_modules/_tile.scss
@@ -32,7 +32,7 @@
     }
   }
 
-  .no-cssgradients & {
+  .modernizr-no-cssgradients & {
     > .wrapper {
       &:before {
         background: transparent neue-asset-url("images/fallbacks/black-gradient.png") 0 bottom repeat-x;
@@ -59,7 +59,7 @@
     width: 100%;
     z-index: 10;
 
-    .no-cssgradients & {
+    .modernizr-no-cssgradients & {
       background: transparent neue-asset-url("images/fallbacks/black-gradient.png") 0 bottom repeat-x;
     }
   }

--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -95,7 +95,7 @@
 
 // If JavaScript is enabled (via Modernizr check), hide inline modal
 // containers to prevent flash of unstyled content as JS initializes.
-.js [data-modal] {
+.modernizr-js [data-modal] {
   display: none;
 }
 

--- a/scss/_regions/_navigation.scss
+++ b/scss/_regions/_navigation.scss
@@ -30,7 +30,7 @@
       .text-field.-search {
         background-image: neue-asset-url("images/search_white.svg");
 
-        .no-svg & {
+        .modernizr-no-svg & {
           background-image: neue-asset-url("images/fallbacks/search_white.png");
         }
       }
@@ -89,7 +89,7 @@
     height: 60px;
   }
 
-  .no-svg &:after {
+  .modernizr-no-svg &:after {
     background: neue-asset-url("images/logo.png");
   }
 
@@ -272,12 +272,12 @@
     @include media($tablet) {
       background-image: neue-asset-url("images/search_black.svg");
 
-      .no-svg & {
+      .modernizr-no-svg & {
         background-image: neue-asset-url("images/fallbacks/search_black.png");
       }
     }
 
-    .no-svg & {
+    .modernizr-no-svg & {
       background-image: neue-asset-url("images/fallbacks/search_white.png");
     }
   }

--- a/styleguide/layout.erb
+++ b/styleguide/layout.erb
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 
-<!--[if lte IE 8 ]> <html dir="ltr" lang="en-US" class="no-js ie8"> <![endif]-->
-<!--[if IE 9 ]> <html dir="ltr" lang="en-US" class="no-js ie9"> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--><html class="no-js"><!--<![endif]-->
+<!--[if lte IE 8 ]> <html dir="ltr" lang="en-US" class="modernizr-no-js ie8"> <![endif]-->
+<!--[if IE 9 ]> <html dir="ltr" lang="en-US" class="modernizr-no-js ie9"> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html class="modernizr-no-js"><!--<![endif]-->
 
 <head>
   <meta charset="utf-8">

--- a/tasks/modernizr.js
+++ b/tasks/modernizr.js
@@ -9,6 +9,9 @@ module.exports = {
         "scss/**/*.scss"
       ]
     },
+    extensibility : {
+      "cssclassprefix": "modernizr-"
+    },
     "extra" : {
       "shiv" : false,
       "teststyles": true,


### PR DESCRIPTION
# Changes
- Adds `modernizr-` prefix to Modernizr classes. This prevents unintentional conflicts with our own pattern/class names, such as `.placeholder` or `.video`.

For review: @DoSomething/front-end 
