### PR TITLE
Remove unused "pin-to-top" sticky classes. References #409.

### DIFF
--- a/scss/_components/_pin-to-top.scss
+++ b/scss/_components/_pin-to-top.scss
@@ -1,7 +1,0 @@
-.is-stuck {
-  @include media($tablet) {
-    position: fixed;
-    top: 0;
-    z-index: 10;
-  }
-}

--- a/scss/neue.scss
+++ b/scss/neue.scss
@@ -34,7 +34,6 @@
 @import "_components/legal";
 @import "_components/message-callout";
 @import "_components/messages";
-@import "_components/pin-to-top";
 @import "_components/social-icon";
 @import "_components/spinner";
 @import "_components/tabs";


### PR DESCRIPTION
# Changes
- Removes `.is-sticky` class used in the removed Neue sticky code. See #409.

For review: @DoSomething/front-end
