### PR TITLE
Moar patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dosomething/forge",
   "description": "Interface framework and pattern library for DoSomething.org.",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "license": "MIT",
   "engines": {
     "node": "0.12.x"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "grunt build && babel js --out-dir lib",
+    "start": "grunt",
     "test": "grunt test"
   },
   "repository": {

--- a/scss/_components/_chat-bubble.scss
+++ b/scss/_components/_chat-bubble.scss
@@ -1,0 +1,33 @@
+// Chat Bubble
+//
+// Used for longer conversational messaging, such as a note from a campaign lead.
+//
+// Markup:
+//   <div class="chat-bubble">
+//     1 items collected! That’s amazing - thanks to everyone for rocking Hunt
+//     Day 2: Trash Scavenger Hunt. Let’s keep it up! Add your contribution in
+//     the Prove It section below.
+//   </div>
+//
+// Styleguide Chat Bubble
+.chat-bubble {
+  position: relative;
+  width: 100%;
+  background-color: $light-gray;
+  border-radius: 10px;
+  padding: $base-spacing;
+  text-align: left;
+  font-size: $font-small;
+  margin-bottom: $base-spacing;
+
+  &:before {
+    position: absolute;
+    content: '';
+    width: 0;
+    height: 0;
+    left: 15%;
+    top: 100%;
+    border: 10px solid;
+    border-color: $light-gray transparent transparent $light-gray;
+  }
+}

--- a/scss/_components/_media-video.scss
+++ b/scss/_components/_media-video.scss
@@ -1,6 +1,6 @@
 // Media Video
 //
-// Applies intrinsic ratio solution to embedded videos to make them responsive.
+// Make embedded videos scale responsively.
 //
 // Markup:
 //   <div class="media-video">

--- a/scss/_components/_message-callout.scss
+++ b/scss/_components/_message-callout.scss
@@ -1,3 +1,5 @@
+// Message Callout
+//
 // Handwritten text callout with arrow pointing to other content.
 //
 // .-below            - Callout is positioned below an element.

--- a/scss/_modules/_cta.scss
+++ b/scss/_modules/_cta.scss
@@ -1,33 +1,52 @@
 // Call To Action
 //
 // The Call To Action module is used to show show a short "call to action" message
-// with an accompanying button. CTAs typically span the full width of the page.
+// with an accompanying button or set of actions. CTAs typically span the full width of the page.
 //
 // Markup:
 //   <div class="cta">
-//     <div class="wrapper">
+//     <div class="cta__block">
 //       <p class="cta__message">Miscreant! You should pay homage to our future kitten overlords:</p>
+//     </div>
+//     <div class="cta__block">
 //       <a href="#" class="button">Support Our Kittens</a>
 //     </div>
+//   </div>
+//   <br/>
+//   <div class="cta">
+//     <div class="cta__block">
+//       <p class="cta__message">Rejoice, and share the good news of our benevolent feline rulers:</p>
+//     </div>
+//     <ul class="cta__actions">
+//       <li><a href="#" class="social-icon -facebook"><span>Facebook</span></a></li>
+//       <li><a href="#" class="social-icon -twitter"><span>Twitter</span></a></li>
+//       <li><a href="#" class="social-icon -tumblr"><span>Tumblr</span></a></li>
+//     </ul>
 //   </div>
 //
 // Styleguide Call To Action
 
 .cta {
   @include clearfix;
-  @include gutters;
   background: lighten($light-gray, 10%);
   border-bottom: 2px solid $light-gray;
   border-top: 2px solid $light-gray;
 
-  > .wrapper {
+  // @DEPRECATED: Prefer new `cta__block` container over `wrapper`.
+  > .wrapper, .cta__block {
     text-align: center;
-    padding: $base-spacing 0;
+    margin: $base-spacing 0;
 
     @include media($tablet) {
       @include span(12);
       @include push(2);
+      float: none;
     }
+  }
+
+  // @NOTE: Hack to keep old `.wrapper` behavior. Will be removed in Forge 7.0
+  > .wrapper .cta__message {
+    margin-bottom: $base-spacing;
   }
 }
 
@@ -35,5 +54,31 @@
   color: $base-font-color;
   font-size: $font-medium;
   font-weight: $weight-sbold;
-  margin: 0 0 $base-spacing;
+}
+
+.cta__actions {
+  width: 100%;
+  display: table;
+
+  li {
+    display: table-cell;
+    text-align: center;
+
+    a {
+      display: block;
+      width: 100%;
+      color: $med-gray;
+      padding: $base-spacing 0;
+    }
+
+    a:hover {
+      background: $blue;
+      color: #fff;
+    }
+
+    .social-icon:after {
+      font-size: 32px;
+    }
+  }
+
 }

--- a/scss/_modules/_social-menu.scss
+++ b/scss/_modules/_social-menu.scss
@@ -1,0 +1,31 @@
+// Social Menu
+//
+// A group of __Social Icons__, used for share actions or linking to social media accounts.
+//
+// .-with-callout - Add additional padding for pairing with an `-above-horizontal` Message Callout.
+//
+// Markup:
+//  <ul class="social-menu {{modifier_class}}">
+//    <li><a class="social-icon -facebook" href="#"><span>Facebook</span></a></li>
+//    <li><a class="social-icon -twitter" href="#"><span>Twitter</span></a></li>
+//    <li><a class="social-icon -tumblr" href="#"><span>Tumblr</span></a></li>
+//  </ul>
+//
+// Styleguide Social Menu
+
+.social-menu {
+  margin: ($base-spacing / 2) 0;
+
+  li {
+    display: inline-block;
+  }
+
+  li + li {
+    margin-left: 12px;
+  }
+
+  // When there is an -above-horizontal message callout above the share bar.
+  &.-with-callout {
+    padding: 0 0 ($base-spacing / 2) $base-spacing;
+  }
+}

--- a/scss/_regions/_container.scss
+++ b/scss/_regions/_container.scss
@@ -4,7 +4,8 @@
 // Modifier classes can be applied to the required `container__block` to use different
 // preset layouts. Optionally, the `container__row` class can be used to align into rows.
 //
-// Apply `.-padded` modifier to add extra bottom padding to a container.
+// Apply `.-padded` modifier to add extra bottom padding to a container, or `.-dark` to
+// use a dark purple background which blends seamlessly with the header.
 //
 // .-narrow - Three-quarters width container.
 // .-half   - Half-width container, can be placed side-by-side to create two-column layouts.
@@ -31,6 +32,11 @@
 
   &.-padded {
     padding-bottom: $base-spacing * 2;
+  }
+
+  &.-dark {
+    background: $purple;
+    color: #fff;
   }
 
   > .wrapper {

--- a/scss/forge.scss
+++ b/scss/forge.scss
@@ -49,11 +49,11 @@
 @import "_components/heading";
 @import "_components/list";
 @import "_components/footnote";
+@import "_components/media-video";
 @import "_components/message-callout";
 @import "_components/messages";
 @import "_components/social-icon";
 @import "_components/spinner";
-@import "_components/video";
 @import "_components/waypoints";
 
 // Modules - basic patterns, may contain other components or modules

--- a/scss/forge.scss
+++ b/scss/forge.scss
@@ -38,6 +38,7 @@
 
 // Components - basic non-divisible building blocks
 @import "_components/avatar";
+@import "_components/chat-bubble";
 @import "_components/_forms/button";
 @import "_components/_forms/field-label";
 @import "_components/_forms/form-actions";

--- a/scss/forge.scss
+++ b/scss/forge.scss
@@ -62,6 +62,7 @@
 @import "_modules/gallery";
 @import "_modules/info-bar";
 @import "_modules/polaroid";
+@import "_modules/social-menu";
 @import "_modules/tabs";
 @import "_modules/tile";
 

--- a/styleguide/index.ejs
+++ b/styleguide/index.ejs
@@ -103,6 +103,7 @@
             <a href="#components" class="js-jump-scroll">Components</a>
             <ul>
               <li><a href="#avatar" class="js-jump-scroll">Avatar</a></li>
+              <li><a href="#chat-bubble" class="js-jump-scroll">Chat Bubble</a></li>
               <li><a href="#forms" class="js-jump-scroll">Forms</a></li>
               <li><a href="#footnote" class="js-jump-scroll">Footnote</a></li>
               <li><a href="#heading" class="js-jump-scroll">Heading</a></li>
@@ -262,6 +263,7 @@
         <p>We don't want to re-invent the wheel. Re-usable interface patterns are catalogued within Forge to promote consistency throughout our interfaces and minimize code bloat. We start by defining atomic components. These are the smallest building blocks of our interfaces.</p>
 
         <%- include('pattern', { pattern: styleguide.section('Avatar') }) %>
+        <%- include('pattern', { pattern: styleguide.section('Chat Bubble') }) %>
 
         <div id="forms">
           <%- include('pattern', { pattern: styleguide.section('Forms - Button') }) %>

--- a/styleguide/index.ejs
+++ b/styleguide/index.ejs
@@ -107,11 +107,11 @@
               <li><a href="#footnote" class="js-jump-scroll">Footnote</a></li>
               <li><a href="#heading" class="js-jump-scroll">Heading</a></li>
               <li><a href="#list" class="js-jump-scroll">List</a></li>
+              <li><a href="#media-video" class="js-jump-scroll">Media Video</a></li>
               <li><a href="#message-callout" class="js-jump-scroll">Message Callout</a></li>
               <li><a href="#messages" class="js-jump-scroll">Messages</a></li>
               <li><a href="#social-icon" class="js-jump-scroll">Social Icon</a></li>
               <li><a href="#spinner" class="js-jump-scroll">Spinner</a></li>
-              <li><a href="#media-video" class="js-jump-scroll">Media Video</a></li>
               <li><a href="#waypoints" class="js-jump-scroll">Waypoints</a></li>
             </ul>
           </li>
@@ -277,11 +277,11 @@
         <%- include('pattern', { pattern: styleguide.section('Footnote') }) %>
         <%- include('pattern', { pattern: styleguide.section('Heading') }) %>
         <%- include('pattern', { pattern: styleguide.section('List') }) %>
+        <%- include('pattern', { pattern: styleguide.section('Media Video') }) %>
         <%- include('pattern', { pattern: styleguide.section('Message Callout') }) %>
         <%- include('pattern', { pattern: styleguide.section('Messages') }) %>
         <%- include('pattern', { pattern: styleguide.section('Social Icon') }) %>
         <%- include('pattern', { pattern: styleguide.section('Spinner') }) %>
-        <%- include('pattern', { pattern: styleguide.section('Media Video') }) %>
         <%- include('pattern', { pattern: styleguide.section('Waypoints') }) %>
 
         <h2 id="modules">Modules</h2>

--- a/styleguide/index.ejs
+++ b/styleguide/index.ejs
@@ -124,6 +124,7 @@
               <li><a href="#gallery" class="js-jump-scroll">Gallery</a></li>
               <li><a href="#info-bar" class="js-jump-scroll">Info Bar</a></li>
               <li><a href="#polaroid" class="js-jump-scroll">Polaroid</a></li>
+              <li><a href="#social-menu" class="js-jump-scroll">Social Menu</a></li>
               <li><a href="#tabs" class="js-jump-scroll">Tabs</a></li>
               <li><a href="#tile" class="js-jump-scroll">Tile</a></li>
             </ul>
@@ -297,6 +298,7 @@
         <%- include('pattern', { pattern: styleguide.section('Gallery - Mosaic') }) %>
         <%- include('pattern', { pattern: styleguide.section('Info Bar') }) %>
         <%- include('pattern', { pattern: styleguide.section('Polaroid') }) %>
+        <%- include('pattern', { pattern: styleguide.section('Social Menu') }) %>
         <%- include('pattern', { pattern: styleguide.section('Tabs') }) %>
         <%- include('pattern', { pattern: styleguide.section('Tile') }) %>
 


### PR DESCRIPTION
# Changes

Add "start" alias for running Grunt. This lets us run `npm start` to build assets and run dev server, and doesn't require user to have `grunt` installed globally. (881239e)

Update documentation and filename for Media Video pattern. Filename didn't match the class name, so just tidying things up. (6b93303)

Add **Social Menu** pattern from Phoenix, used for groups of social icons. (b9ddd23)
<img width="588" alt="screen shot 2015-09-09 at 4 45 33 pm" src="https://cloud.githubusercontent.com/assets/583202/9773772/5447c42c-5712-11e5-9511-0b286f921a3e.png">

Add **Chat Bubble** pattern from Phoenix, used in the Hot Module. (727a679)
<img width="588" alt="screen shot 2015-09-09 at 4 45 57 pm" src="https://cloud.githubusercontent.com/assets/583202/9773766/461c1ae2-5712-11e5-94aa-5a74567c33c5.png">

Add "actions" to the **CTA** pattern, as seen on the reportback confirmation page. One thing that changes (with maintained backwards compatibility) is moving from `.wrapper` inner class to `.cta__block`, since there are scenarios where we might want more than one. (3465395)
<img width="589" alt="screen shot 2015-09-09 at 4 45 17 pm" src="https://cloud.githubusercontent.com/assets/583202/9773768/4c89b3b2-5712-11e5-84c4-0bc7e86e998e.png">

Add "dark" modifier to Container pattern, as seen on the reportback confirmation page. (6e8934e)

:cactus: 

For review: @DoSomething/front-end 
