### PR TITLE
Add pattern search

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can also run the pattern library on your local machine! Here's the steps:
 
   1. Fork & clone this repository.
   2. Run `npm install` to configure dependencies.
-  3. Run `grunt` to build assets, watch for changes, and run styleguide server.
+  3. Run `npm start` to build assets, watch for changes, and run styleguide server.
   4. Check it out at `localhost:3000` in your browser!
 
 ### License

--- a/scss/styleguide.scss
+++ b/scss/styleguide.scss
@@ -277,3 +277,22 @@ main {
   background: #fff url("/styleguide/assets/pattern-dark-bg.png");
 }
 
+
+.text-field.-search.styleguide-filter {
+  border: 0;
+  background-position: 0 50%;
+  padding-left: 18px;
+
+  &:focus {
+    border: 0;
+    box-shadow: none;
+  }
+}
+
+.waypoints li.is-hidden {
+  display: none;
+}
+
+.waypoints li.is-expanded ul {
+  max-height: 600px;
+}

--- a/styleguide/assets/kss.js
+++ b/styleguide/assets/kss.js
@@ -1,4 +1,6 @@
 (function() {
+  var $ = window.jQuery;
+
   /**
    * Generate KSS state previews.
    */
@@ -99,6 +101,68 @@
       e.preventDefault();
       $(".js-styleguide-navigation").toggleClass("is-hidden");
     });
+  });
+
+  /**
+   * Filtering!
+   */
+  function includes(text, term) {
+    return text.indexOf(term) !== -1;
+  }
+
+  $(document).ready(function() {
+
+    // Press `t` to filter patterns
+    $(document).on('keydown', function(event) {
+      if (event.target !== document.body) return;
+
+      if(event.keyCode === 84) {
+        event.preventDefault();
+        $('.js-styleguide-filter').focus();
+      }
+    });
+
+    // Live filtering
+    $('.js-styleguide-filter').on('keyup', function(event) {
+      var term = $(this).val().toLowerCase();
+      var $items = $('.js-styleguide-navigation li');
+
+      // "Jump" to first match if enter is pressed
+      if (event.keyCode === 13) {
+        event.preventDefault();
+
+        var $first = $items.filter('.is-expanded:not(.is-hidden)').first();
+
+        var $child = $first.find('.is-expanded:not(is-hidden)');
+        if ($child.length) {
+          $first = $child;
+        }
+
+        $first.find('a').first().trigger('click');
+      }
+
+      // Remove classes if search field is emptied
+      if (term === '') {
+        $items
+          .removeClass('is-expanded')
+          .removeClass('is-hidden');
+
+        return;
+      }
+
+      $items.each(function() {
+        var contents = $(this).text().toLowerCase();
+
+        if (includes(contents, term)) {
+          $(this).addClass('is-expanded');
+          $(this).removeClass('is-hidden');
+        } else {
+          $(this).addClass('is-hidden');
+        }
+      });
+
+    });
+
   });
 
 }).call(this);

--- a/styleguide/index.ejs
+++ b/styleguide/index.ejs
@@ -86,6 +86,9 @@
     <main>
       <nav class="styleguide-sidebar js-fixedsticky">
         <a href="#" class="secondary styleguide-navigation-toggle js-styleguide-navigation-toggle">Table of Contents</a>
+        <form class="filter">
+          <input type="search" placeholder="Search..." class="text-field -search styleguide-filter js-styleguide-filter">
+        </form>
         <ul class="waypoints -vertical js-scroll-indicator js-styleguide-navigation">
           <li><a href="#intro" class="js-jump-scroll">Introduction</a></li>
 


### PR DESCRIPTION
Adds a search box to the side navigation to let you search by pattern name. I'd been wanting this for a long time and never got around to hacking something together.

![screen shot 2015-09-11 at 2 26 22 pm](https://cloud.githubusercontent.com/assets/583202/9822889/163cb91e-5891-11e5-8462-eeedb5ff1e47.png)
#### Secrets :sparkles:
- Press `t` to select the search box (just like searching for files on Github).
- Once you've typed something in the search box, press `enter` to scroll to the first matching result.

:cactus: 

For review: @DoSomething/front-end 
