### PR TITLE
Fix figure with less content

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^16.0.0",
     "grunt-express-server": "^0.4.19",
-    "grunt-modernizr": "^0.6.0",
+    "grunt-modernizr": "metaloha/grunt-modernizr#d6657bf302bd9288e25a513197fb0e30c64ce677",
     "grunt-postcss": "^0.2.0",
     "grunt-sass": "^0.18.0",
     "grunt-sasslint": "0.0.5",

--- a/scss/_modules/_figure.scss
+++ b/scss/_modules/_figure.scss
@@ -35,6 +35,7 @@
     > .figure__media {
       float: left;
       padding-right: gutter();
+      margin: 0;
     }
 
     > .figure__body {
@@ -73,6 +74,7 @@
     > .figure__media {
       float: right;
       padding-left: gutter();
+      margin: 0;
     }
 
     > .figure__body {

--- a/scss/_modules/_figure.scss
+++ b/scss/_modules/_figure.scss
@@ -41,19 +41,29 @@
       overflow: hidden;
       padding-left: gutter();
     }
+  }
 
-    &.-center {
-      display: table;
+  // @NOTE: This modifier only pairs with `.left`!
+  &.-center {
+    display: table;
 
-      .figure__media {
-        margin: 0px;
-        display: table-cell;
-      }
+    // We use `table-cell` display property to let us vertically
+    // align the contents of the figure.
+    .figure__body, .figure__media {
+      display: table-cell;
+      vertical-align: middle;
+    }
 
-      .figure__body {
-        display: table-cell;
-        vertical-align: middle;
-      }
+    // Remove `max-width` rule from images, because otherwise
+    // the media table-cell just collapses!
+    .figure__media > img {
+      max-width: none;
+    }
+
+    // Hack to force the body to take up all of the space
+    // in the table that the `.figure__media` does not.
+    .figure__body {
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
# Changes

References DoSomething/phoenix#5139. Slightly reworks the `.-center` modifier to fix an issue where the body doesn't fill the figure if it doesn't have enough text to fill the cell's width. 

I'd recommend checking out [the final code](https://github.com/DFurnes/forge/blob/b8b6a87794351e15d2064ae0cc75ca0852ff4ca5/scss/_modules/_figure.scss#L47-L69) for the `.-center` modifier, since the diff gets a bit muddied by indentation and shifting things around for readability. The commit comments & inline comments in the code also have more rationale for each change.
# Screenshots

Sad misaligned cat, taken from the 6.6.0 release:
![screen shot 2015-09-17 at 11 02 27 am](https://cloud.githubusercontent.com/assets/583202/9937066/15fe7f3c-5d2d-11e5-8624-47dd4c6de31f.png)

Happy, correctly aligned cat (this branch):
![screen shot 2015-09-17 at 11 01 32 am](https://cloud.githubusercontent.com/assets/583202/9937085/2ff17840-5d2d-11e5-9db9-0f521f47fa21.png)

And still lookin' good with a larger text block (this branch):
![screen shot 2015-09-17 at 11 01 15 am](https://cloud.githubusercontent.com/assets/583202/9937094/36a1d8c4-5d2d-11e5-9bb6-e74b7d6bb625.png)

---

@DoSomething/front-end 
