### PR TITLE
Ummm applies a fix for figures on mobile that only had padding on one…

### DIFF
--- a/scss/_modules/_figure.scss
+++ b/scss/_modules/_figure.scss
@@ -36,11 +36,21 @@
       float: left;
       padding-right: gutter();
       margin: 0;
+
+      // Adds in a left-side gutter to balance within the page
+      @include media($mobile) {
+        padding-left: gutter();
+      }
     }
 
     > .figure__body {
       overflow: hidden;
       padding-left: gutter();
+
+      // Adds in a right-side gutter to balance within the page
+      @include media($mobile) {
+        padding-right: gutter();
+      }
     }
   }
 


### PR DESCRIPTION
… side

Up for discussion, I added padding on the other side to balance it out.
Removing the padding overall on mobile did some funky things I didn’t
quite understand but the text got pushed around.
