### PR TITLE
Update banner styling for Forge 6.7

### DIFF
--- a/scss/_components/_heading.scss
+++ b/scss/_components/_heading.scss
@@ -7,7 +7,8 @@
 // .-beta   - Beta heading, default appearance for <code>h2</code> tags
 // .-gamma  - Gamma heading, default appearance for <code>h3</code> tags
 // .-delta  - Delta heading, default appearance for <code>h4</code>, <code>h5</code>, and <code>h6</code> tags
-// .-banner - Stylized header banners.
+// .-banner - Stylized header banner.
+// .-banner.-inverse - Stylized header banner (for yellow backgrounds).
 //
 // Markup: <h2 class="heading {{modifier_class}}"><span>Heading</span></h2>
 //
@@ -48,6 +49,13 @@ h1, h2, h3, h4, h5, h6,
       height: 6px;
       background: $yellow;
     }
+  }
+}
+
+// An alternate version of the "banner" for use on yellow backgrounds.
+.heading.-banner.-inverse {
+  span:after {
+    background: $white;
   }
 }
 

--- a/scss/_components/_heading.scss
+++ b/scss/_components/_heading.scss
@@ -27,16 +27,26 @@ h1, h2, h3, h4, h5, h6,
 
 .heading.-banner {
   @include clearfix;
-  background: $black;
-  color: $white;
+  color: $black;
   text-transform: uppercase;
-  padding: gutter();
   margin: 0;
 
   span {
+    display: block;
+    padding: $base-spacing gutters() 0;
+
     @include media($medium) {
       @include span(12 no-gutters);
       @include push(2);
+    }
+
+    &:after {
+      content: '';
+      display: block;
+      width: 330px;
+      max-width: 100%;
+      height: 6px;
+      background: $yellow;
     }
   }
 }


### PR DESCRIPTION
#### Changes

Some fresh new CSS! This PR adds the new banner style that's going to be introduced in Forge 6.7 to the pattern library, replacing the old banner style. :art: 
#### Screenshots

With shorter heading text:
<img width="471" alt="screen shot 2016-03-21 at 3 51 13 pm" src="https://cloud.githubusercontent.com/assets/583202/13932051/c51e503c-ef7c-11e5-95ed-b9c55e861124.png">

With longer text that expands past the yellow bar:
<img width="643" alt="screen shot 2016-03-21 at 3 38 27 pm" src="https://cloud.githubusercontent.com/assets/583202/13931894/e0a4ba5e-ef7b-11e5-8801-b5106d535c4f.png">

With extra-long text that wraps to another line:
<img width="612" alt="screen shot 2016-03-21 at 3 39 07 pm" src="https://cloud.githubusercontent.com/assets/583202/13931914/f390bb68-ef7b-11e5-8491-639bd6b59b21.png">

And here it is on the profile page:
![screen shot 2016-03-21 at 4 34 33 pm](https://cloud.githubusercontent.com/assets/583202/13933303/de631d42-ef82-11e5-8c3c-cc2dc0dab1df.png)

And on the action page:
![screen shot 2016-03-21 at 4 34 41 pm](https://cloud.githubusercontent.com/assets/583202/13933299/d91ac27c-ef82-11e5-807d-5db027197fc1.png)

And finally, here's how things look on mobile devices:
<img width="288" alt="screen shot 2016-03-21 at 4 42 51 pm" src="https://cloud.githubusercontent.com/assets/583202/13933552/1b171a6c-ef84-11e5-94a1-5f54d7dfb490.png">

---

For review: @DoSomething/front-end @lkpttn 
