### PR TITLE
Don't bundle jQuery with Forge.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,4 +5,14 @@ module.exports = config({
     forge: './index.js',
     styleguide: './styleguide/styleguide.js'
   },
+  
+  // Don't bundle the 'jquery' package with the library (forge.js), but
+  // instead load from `jQuery` global variable or AMD/CJS package.
+  externals: {
+    'jquery': {
+      root: 'jQuery',
+      commonjs2: 'jquery',
+      amd: 'jquery'
+    }
+  },
 });


### PR DESCRIPTION
#### Changes

I had originally included this in the shared Webpack config, but we don't really want this behavior anywhere besides Forge. So I removed this from the shared config in v1.1 and added it in here. :hammer: 

---

For review: @DoSomething/front-end 
