### PR TITLE
Gallery updates for Forge 6.7

### DIFF
--- a/scss/_modules/_figure.scss
+++ b/scss/_modules/_figure.scss
@@ -34,8 +34,8 @@
 
     > .figure__media {
       float: left;
-      padding-right: gutter();
-      margin: 0;
+      margin-right: gutter();
+      margin-bottom: 0;
     }
 
     > .figure__body {
@@ -72,8 +72,8 @@
 
     > .figure__media {
       float: right;
-      padding-left: gutter();
-      margin: 0;
+      margin-left: gutter();
+      margin-bottom: 0;
     }
 
     > .figure__body {
@@ -92,6 +92,16 @@
       img {
         width: 100%;
       }
+    }
+  }
+
+  &.-tinted {
+    border-radius: $lg-border-radius;
+    background: $off-white;
+    overflow: hidden;
+
+    > .figure__body {
+      margin: gutter();
     }
   }
 }

--- a/scss/_modules/_figure.scss
+++ b/scss/_modules/_figure.scss
@@ -6,6 +6,7 @@
 // .-left.-center - Show a figure's media to the left of the description, with the text vertically centered.
 // .-right   - Show figure's media to the right of the description.
 // .-medium  - Set figure's media to a fixed "medium" size.
+// .-tinted.-left - Tinted figure appearance, with a solid background & rounded edges. Should be paired with either the `.-left` or `.-right` modifiers.
 //
 // Markup:
 //   <article class="figure {{modifier_class}}">

--- a/scss/_modules/_figure.scss
+++ b/scss/_modules/_figure.scss
@@ -40,7 +40,6 @@
 
     > .figure__body {
       overflow: hidden;
-      padding-left: gutter();
     }
   }
 
@@ -79,7 +78,6 @@
 
     > .figure__body {
       overflow: hidden;
-      padding-right: gutter();
     }
   }
 
@@ -100,7 +98,7 @@
 
 .figure__media {
   text-align: center;
-  margin: 0 auto $base-spacing;
+  margin: 0 auto gutter() / 2;
 
   img {
     margin: 0 auto;

--- a/scss/_utilities/_variables.scss
+++ b/scss/_utilities/_variables.scss
@@ -48,6 +48,7 @@ $off-black: #222;
 $dark-gray: #444;
 $med-gray: #999;
 $light-gray: #ddd;
+$off-white: #f6f6f6;
 $white: #fff;
 
 $base-background-color: $light-gray;
@@ -92,7 +93,6 @@ $base-font-size: $font-regular;
 $unitless-line-height: 1.4444444;
 $header-line-height: 1.2;
 $comfortable-line-height: 1.5625; // ~28.125px at 18px
-
 
 // Measurements
 $base-spacing: 24px;


### PR DESCRIPTION
## Changes

This PR includes updates to the Figure pattern for the new galleries in Forge 6.7.

From @lkpttn's design document:

> ### Problem 2 - Gallery Content
> 
> We’ve also created a number of new galleries since we implemented our current site two years ago. We’ve worked with a basic set of patterns but haven’t often adapted them to their new use cases. Again, as we prepare for a larger focus on member story telling, we’d like to augment our galleries.
> ##### How we want to solve it
> 
> Most of these fixes are low intensity, modifying existing patterns. We’re targeting the galleries which you see most frequently on static content pages, closed campaigns and your profile while introducing some new styles.
> #### Redesigned duo gallery / figure-left .small
> 
> The small `.figure-left` left pattern is getting a redesign to allow for better grouping. We’ll stop using the pattern for things like celebrity tweets and use it for content you skim through like search results and the profile. This should create stronger content blocks where it’s easier to sift for information you want.
> #### Padding changes
> 
> Padding between a trio gallery has decreased from `24px` to `6px`. Previously, the generous padding led to a disconnect between gallery images and captions. This change should clear up any ambiguity.
## Screenshots

Duo gallery with tinted left figures, on the user profile page:
![screen shot 2016-03-25 at 3 50 17 pm](https://cloud.githubusercontent.com/assets/583202/14052513/4c57e424-f2a1-11e5-8add-c4752031fe01.png)

Updated figure padding in a trio gallery, on the static content template:
![screen shot 2016-03-25 at 3 45 36 pm](https://cloud.githubusercontent.com/assets/583202/14052479/05a11e10-f2a1-11e5-90f3-630fe92ec43a.png)

---

For review: @DoSomething/front-end @lkpttn 
