### PR TITLE
Adds Bragging Gallery pattern & updates Heading pattern.

### DIFF
--- a/scss/_components/_heading.scss
+++ b/scss/_components/_heading.scss
@@ -7,8 +7,9 @@
 // .-beta   - Beta heading, default appearance for <code>h2</code> tags
 // .-gamma  - Gamma heading, default appearance for <code>h3</code> tags
 // .-delta  - Delta heading, default appearance for <code>h4</code>, <code>h5</code>, and <code>h6</code> tags
-// .-banner - Stylized header banner.
-// .-banner.-inverse - Stylized header banner (for yellow backgrounds).
+// .-banner - ~~Stylized header banner with included gutter.~~ (Deprecated. Use `.-emphasized` instead, using Container pattern for appropriate margins.)
+// .-emphasized - Stylized heading with a heavy yellow underline.
+// .-emphasized.-inverse - Stylized heading with a heavy white underline (for use on yellow backgrounds).
 //
 // Markup: <h2 class="heading {{modifier_class}}"><span>Heading</span></h2>
 //
@@ -26,8 +27,9 @@ h1, h2, h3, h4, h5, h6,
   text-rendering: optimizeLegibility;
 }
 
+// @DEPRECATED: Gives old `.heading.-banner` elements the appearance
+// of the new "emphasized" heading pattern with appropriate padding.
 .heading.-banner {
-  @include clearfix;
   color: $black;
   text-transform: uppercase;
   margin: 0;
@@ -52,9 +54,25 @@ h1, h2, h3, h4, h5, h6,
   }
 }
 
-// An alternate version of the "banner" for use on yellow backgrounds.
-.heading.-banner.-inverse {
-  span:after {
+// Emphasized heading with heavy yellow underline.
+.heading.-emphasized {
+  color: $black;
+  text-transform: uppercase;
+  padding: 0 0 gutter();
+  overflow: hidden;
+  margin: 0;
+
+  &:after {
+    content: '';
+    display: block;
+    width: 330px;
+    max-width: 100%;
+    height: 5px;
+    background: $yellow;
+  }
+
+  // An alternate version of the "banner" for use on yellow backgrounds.
+  &.-inverse:after {
     background: $white;
   }
 }

--- a/scss/_components/_heading.scss
+++ b/scss/_components/_heading.scss
@@ -58,7 +58,7 @@ h1, h2, h3, h4, h5, h6,
 .heading.-emphasized {
   color: $black;
   text-transform: uppercase;
-  padding: 0 0 gutter();
+  padding: 0 0 $base-spacing;
   overflow: hidden;
   margin: 0;
 

--- a/scss/_modules/_bragging.scss
+++ b/scss/_modules/_bragging.scss
@@ -1,0 +1,18 @@
+// Bragging Gallery
+//
+// Did we kill it on something? This is the perfect component for showcasing a large photo with a bit of text attached.
+// This could be a great media snapshot, celebrity endorsment or even a member callout.
+//
+// Markup:
+//   <article class="figure -left -center">
+//     <div class="figure__media">
+//       <img alt="winning cat" src="/styleguide/assets/placeholder.jpg" />
+//     </div>
+//     <div class="figure__body">
+//       <h2 class="heading -emphasized">Grand Prize</h2>
+//       <p><strong>Look at this cat.</strong> How'd she get so god-damned cute?
+//       What gives her the right? Who does she think she is?</p>
+//     </div>
+//   </article>
+//
+// Styleguide Bragging Gallery

--- a/scss/_modules/_figure.scss
+++ b/scss/_modules/_figure.scss
@@ -6,7 +6,6 @@
 // .-left.-center - Show a figure's media to the left of the description, with the text vertically centered.
 // .-right   - Show figure's media to the right of the description.
 // .-medium  - Set figure's media to a fixed "medium" size.
-// .-tinted.-left - Tinted figure appearance, with a solid background & rounded edges. Should be paired with either the `.-left` or `.-right` modifiers.
 //
 // Markup:
 //   <article class="figure {{modifier_class}}">
@@ -93,16 +92,6 @@
       img {
         width: 100%;
       }
-    }
-  }
-
-  &.-tinted {
-    border-radius: $lg-border-radius;
-    background: $off-white;
-    overflow: hidden;
-
-    > .figure__body {
-      margin: gutter();
     }
   }
 }

--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -24,25 +24,28 @@
 // Additional styles for modals.
 // See http://www.github.com/DoSomething/modal
 [data-modal] {
-  .heading.-banner {
+  overflow: hidden;
+
+  .heading.-emphasized {
     // make space for "x" button on the right.
-    padding: $base-spacing 72px $base-spacing $base-spacing;
+    margin: $base-spacing 72px $base-spacing $base-spacing;
+    padding: 0;
   }
-}
 
-.modal-close-button {
-  color: $med-gray;
-  top: 12px;
+  .modal-close-button {
+    color: $med-gray;
+    top: 6px;
 
-  @include media($medium) {
-    font-size: 42px;
+    @include media($medium) {
+      font-size: 42px;
+    }
   }
 }
 
 // Modal content block
 // Adds proper spacing around content in modal.
 .modal__block {
-  padding: $base-spacing;
+  margin: $base-spacing;
 }
 
 // Add support for modal overlay in IE8

--- a/styleguide/index.ejs
+++ b/styleguide/index.ejs
@@ -123,6 +123,7 @@
           <li>
             <a href="#modules" class="js-jump-scroll">Modules</a>
             <ul>
+              <li><a href="#bragging-gallery" class="js-jump-scroll">Bragging Gallery</a></li>
               <li><a href="#call-to-action" class="js-jump-scroll">Call To Action</a></li>
               <li><a href="#figure" class="js-jump-scroll">Figure</a></li>
               <li><a href="#gallery" class="js-jump-scroll">Gallery</a></li>
@@ -293,6 +294,7 @@
         <h2 id="modules">Modules</h2>
         <p>Modules are groups of components, and generally work as a standalone part of an interface. They may even contain other modules (for example, the gallery module contains multiple tile modules).</p>
 
+        <%- include('pattern', { pattern: styleguide.section('Bragging Gallery') }) %>
         <%- include('pattern', { pattern: styleguide.section('Call To Action') }) %>
         <%- include('pattern', { pattern: styleguide.section('Figure') }) %>
         <%- include('pattern', { pattern: styleguide.section('Gallery') }) %>


### PR DESCRIPTION
## Changes

Adds the new Bragging Gallery "pattern" to the pattern library. It doesn't have any unique styles since it's just a combination of other existing patterns, but I think it still seems worth including in the pattern library since the design team has labeled this as a formalized pattern... thoughts?

![screen shot 2016-03-28 at 11 47 44 am](https://cloud.githubusercontent.com/assets/583202/14082002/978848bc-f4db-11e5-8a75-822df597d1f8.png)

This PR also adds the `.-emphasized` Heading modifier suggested by @weerd in #537, which has the same styles we apply to `.heading.-banner`, but without the included margins (since that's a layout concern that doesn't really belong in a visual appearance pattern like this).

![screen shot 2016-03-28 at 11 55 07 am](https://cloud.githubusercontent.com/assets/583202/14082069/f0990fb8-f4db-11e5-9b82-844a533f669f.png)

And that's it for Forge 6.7! :clap: 

---

For review: @DoSomething/front-end @lkpttn 
