### PR TITLE
Forge 6.7: Last Call

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@dosomething/eslint-config": "^1.1.0",
     "@dosomething/webpack-config": "^1.0.0",
     "babel-cli": "^6.6.5",
-    "babel-eslint": "^5.0.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "dosomething-modal": "^0.3.0",

--- a/scss/_components/_heading.scss
+++ b/scss/_components/_heading.scss
@@ -58,7 +58,6 @@ h1, h2, h3, h4, h5, h6,
 .heading.-emphasized {
   color: $black;
   text-transform: uppercase;
-  padding: 0 0 $base-spacing;
   overflow: hidden;
   margin: 0;
 

--- a/scss/_modules/_figure.scss
+++ b/scss/_modules/_figure.scss
@@ -98,7 +98,7 @@
 
 .figure__media {
   text-align: center;
-  margin: 0 auto gutter() / 2;
+  margin: 0 auto gutter();
 
   img {
     margin: 0 auto;

--- a/scss/_modules/_tile.scss
+++ b/scss/_modules/_tile.scss
@@ -80,7 +80,7 @@
 
   .tile__flag {
     color: #000;
-    font-size: $font-smaller;
+    font-size: $font-small;
     font-weight: $weight-sbold;
     left: 0;
     line-height: 1;

--- a/scss/_regions/_container.scss
+++ b/scss/_regions/_container.scss
@@ -50,7 +50,8 @@
     .container__block {
       // When inside a container wrapper, increase top/bottom padding
       // on the container body.
-      padding: $base-spacing gutters();
+      padding: 0 gutters();
+      margin: $base-spacing 0;
       line-height: $comfortable-line-height;
 
       &.-narrow {
@@ -72,6 +73,11 @@
   // Use container rows to separate rows in columned layouts.
   .container__row {
     @include clearfix;
+    margin: $base-spacing 0;
+
+    > .container__block {
+      margin: 0;
+    }
   }
 
   // Use container body for all container content, with optional modifiers

--- a/scss/_regions/_footer.scss
+++ b/scss/_regions/_footer.scss
@@ -162,7 +162,7 @@
 
   a {
     display: block;
-    font-size: $font-smaller;
+    font-size: $font-small;
     color: $med-gray;
     padding: ($base-spacing / 4) 0;
 
@@ -178,7 +178,7 @@
 
 .footer__subfooter {
   clear: both;
-  font-size: $font-smaller;
+  font-size: $font-small;
   border-top: 1px solid $dark-gray;
   padding: ($base-spacing / 2);
 

--- a/scss/_regions/_navigation.scss
+++ b/scss/_regions/_navigation.scss
@@ -231,7 +231,7 @@
   }
 
   .navigation__subtitle {
-    font-size: $font-smaller;
+    font-size: $font-small;
     opacity: 0.8;
 
     @include media($tablet) {

--- a/scss/_utilities/_variables.scss
+++ b/scss/_utilities/_variables.scss
@@ -87,7 +87,7 @@ $font-large: type-scale(2); // 28.125px
 $font-medium: type-scale(1); // 22.500px
 $font-regular: type-scale(0); // 18.000px
 $font-small: type-scale(-1); // 14.400px
-$font-smaller: type-scale(-1); // DEPRECATED: Use $font-small.
+$font-smaller: $font-small; // DEPRECATED: Use $font-small.
 
 $base-font-size: $font-regular;
 $unitless-line-height: 1.4444444;

--- a/scss/_utilities/_variables.scss
+++ b/scss/_utilities/_variables.scss
@@ -87,7 +87,7 @@ $font-large: type-scale(2); // 28.125px
 $font-medium: type-scale(1); // 22.500px
 $font-regular: type-scale(0); // 18.000px
 $font-small: type-scale(-1); // 14.400px
-$font-smaller: type-scale(-2); // 11.520px
+$font-smaller: type-scale(-1); // DEPRECATED: Use $font-small.
 
 $base-font-size: $font-regular;
 $unitless-line-height: 1.4444444;


### PR DESCRIPTION
#### Changes

Closes #542. The _last_ round of changes for Forge 6.7:
- Removes padding from emphasized headings, since this should be handled by a container! This means we can just use `container__block` to space out these headings like we do other sections when we use them.
- Use margins for vertical spacing between container rows, since that'll collapse so that we have consistent 24px spacing between rows, rather than 24px at the top and bottom and 48px between adjacent rows.
- Deprecates the `$font-smaller` option, since we noticed that made some text way to small to be comfortably readable. I left the variable in as an "alias" to `$font-small` so we don't break any app code.
- Increase spacing between figure media and body from 6px to 12px.

---

For review: @DoSomething/front-end
