### PR TITLE
Fix style guide deploys...

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@dosomething/eslint-config": "^1.1.0",
     "@dosomething/webpack-config": "^1.0.0",
     "babel-cli": "^6.6.5",
-    "babel-eslint": "^5.0.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "dosomething-modal": "^0.3.0",

--- a/styleguide/app.js
+++ b/styleguide/app.js
@@ -34,7 +34,7 @@ app.get('/', function(req, res) {
 });
 
 // Start 'er up!
-const PORT = 3000;
+const PORT = process.env.STYLEGUIDE_PORT || 3000;
 app.listen(PORT, function() {
   console.log(`Pattern Library running on 'http://localhost:${PORT}'.`);
 });

--- a/styleguide/index.ejs
+++ b/styleguide/index.ejs
@@ -12,8 +12,8 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
-  <link rel="shortcut icon" href="dist/assets/images/favicon.ico">
-  <link rel="apple-touch-icon-precomposed" href="dist/assets/images/apple-touch-icon-precomposed.png">
+  <link rel="shortcut icon" href="/assets/images/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" href="/assets/images/apple-touch-icon-precomposed.png">
 
   <link rel="stylesheet" href="node_modules/dosomething-modal/dist/modal.css" media="screen, projection" type="text/css">
   <link rel="stylesheet" href="node_modules/dosomething-validation/dist/validation.css" media="screen, projection" type="text/css">

--- a/wercker.yml
+++ b/wercker.yml
@@ -19,7 +19,7 @@ deploy:
           export STYLEGUIDE_PORT=8000
           npm run styleguide &
           sleep 5 # let Node start up!
-          wget -mpc --user-agent="" -e robots=off -P build -nH http://localhost:8000/
+          wget -mpc --user-agent="" -e robots=off -P build -nH http://localhost:${STYLEGUIDE_PORT}/
     - lukevivier/gh-pages:
         token: $GH_TOKEN
         domain: forge.dosomething.org

--- a/wercker.yml
+++ b/wercker.yml
@@ -15,10 +15,11 @@ deploy:
     - script:
         name: build static pattern library
         code: |-
-          export NODE_ENV='production'
-          npm run styleguide
+          export NODE_ENV=production
+          export STYLEGUIDE_PORT=8000
+          npm run styleguide &
           sleep 5 # let Node start up!
-          wget -mpc --user-agent="" -e robots=off -P build -nH http://localhost:3000/
+          wget -mpc --user-agent="" -e robots=off -P build -nH http://localhost:8000/
     - lukevivier/gh-pages:
         token: $GH_TOKEN
         domain: forge.dosomething.org


### PR DESCRIPTION
#### Changes

The Node box for Wercker's new Docker stack apparently only allows localhost connections on port 8000! Tricky Docker. :whale: :eyes: This PR adds the ability to set a custom port when running the style guide, and fixes two 404ing URLs in the default layout.

It also cherry-picks 6d40e2e from #544.

---

For review: @DoSomething/front-end
