### PR TITLE
Create pattern library on build step.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -8,10 +8,6 @@ build:
         name: build production assets
         code: npm run build
     - npm-test
-
-# Automatically deploy `dev` branch to Github pages
-deploy:
-  steps:
     - script:
         name: build static pattern library
         code: |-
@@ -20,6 +16,10 @@ deploy:
           npm run styleguide &
           sleep 5 # let Node start up!
           wget -mpc --user-agent="" -e robots=off -P build -nH http://localhost:${STYLEGUIDE_PORT}/
+
+# Automatically deploy `dev` branch to Github pages
+deploy:
+  steps:
     - lukevivier/gh-pages:
         token: $GH_TOKEN
         domain: forge.dosomething.org


### PR DESCRIPTION
#### Changes

Okay, I lied in #545. It seems like you can only access local ports on the "build" step, and not the "deploy" step. Anyways, I guess this is technically a part of the "build" so it doesn't hurt to move it.

---

For review: @DoSomething/front-end
