### PR TITLE
Remove engines specification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "description": "Interface framework and pattern library for DoSomething.org.",
   "version": "6.6.2",
   "license": "MIT",
-  "engines": {
-    "node": "0.12.x"
-  },
   "babel": {
     "presets": [
       "es2015",


### PR DESCRIPTION
Don't require node version explicitly.

This is to remove NPM dependencies warning:

```
npm WARN engine @dosomething/forge@6.6.2: wanted: {"node":"0.12.x"} (current: {"node":"4.4.0","npm":"2.14.20"})
```

See explanation https://github.com/DoSomething/phoenix/issues/5921#issuecomment-169712675.
