### PR TITLE
Properly override styles for alt modal button.

### DIFF
--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -39,6 +39,11 @@
     @include media($medium) {
       font-size: 42px;
     }
+
+    &.-alt {
+      font-size: $font-regular;
+      top: 30px; // Magic number to align in center of where "X" would be.
+    }
   }
 }
 


### PR DESCRIPTION
#### Changes

The default styles packaged in [dosomething-modal](https://www.github.com/dosomething/modal) cause some visual glitches in Forge 6.7. This is a quick fix to get that "skip" button on the Signup Data Form to appear properly. References DoSomething/phoenix#6347.
#### Screenshots

![screen shot 2016-04-08 at 11 27 10 am](https://cloud.githubusercontent.com/assets/583202/14388624/f4e1d4ca-fd7c-11e5-9e64-35a19c803a7f.png)

---

For review: @DoSomething/front-end 
