### PR TITLE
Updates to adjust for modified footer social icons.

### DIFF
--- a/scss/_regions/_footer.scss
+++ b/scss/_regions/_footer.scss
@@ -102,7 +102,8 @@
       }
 
       .social-icon {
-        margin: ($base-spacing / 2);
+        margin: 8px;
+        padding: 1px 1px 0;
 
         @include media($tablet) {
           margin-top: 0;

--- a/scss/_regions/_footer.scss
+++ b/scss/_regions/_footer.scss
@@ -102,6 +102,13 @@
       }
 
       .social-icon {
+        // @TODO: The margin value was revised to account for an increase in number of
+        // social media icons, and the row of them breaking when the viewport was too
+        // narrow. It's something to address in the future, and maybe remove some of
+        // these styles and let the theme implementing Forge decide on spacing, or
+        // maybe just have the theme override the default values specified here?
+        // The new padding value accounts for wide icons that get cut off even if
+        // same height as other icons.
         margin: 8px;
         padding: 1px 1px 0;
 


### PR DESCRIPTION
#### What's this PR do?

This PR provides some quick adjustments to help fix some visual bugs with a couple newly added social media icons in the footer.
#### How should this be manually tested?

Make sure the Heart icon for "We Heart It" is no longer getting cut off, and make sure on narrow viewport (right before it switches to mobile single column view), the last icon in the row doesn't pop off the row and drop to the next line.
#### What are the relevant tickets?

Refs #6598
#### Screenshots (if appropriate)

<img width="454" alt="screen shot 2016-06-23 at 10 55 35 am" src="https://cloud.githubusercontent.com/assets/105849/16314993/3ecac288-3935-11e6-90ee-b4ccfc201bb0.png">

<img width="447" alt="screen shot 2016-06-23 at 10 55 51 am" src="https://cloud.githubusercontent.com/assets/105849/16315001/446c310e-3935-11e6-9353-c27757d80e02.png">

---

@DFurnes 
