### PR TITLE
add hidden overflow for gallery li's

### DIFF
--- a/scss/_modules/_gallery.scss
+++ b/scss/_modules/_gallery.scss
@@ -20,6 +20,7 @@
   > li {
     margin: gutter() 0;
     padding: 0 gutter();
+    overflow: hidden;
   }
 
   // Gallery - Quartet


### PR DESCRIPTION
Related to [this PR](https://github.com/DoSomething/phoenix/pull/7022) and [this issue](https://github.com/DoSomething/phoenix/issues/6945) in Phoenix where gallery items were getting their bodies cut off on small screens.

Before:

![image](https://cloud.githubusercontent.com/assets/4240292/18400456/fad3b380-76a3-11e6-8be3-b04aef03a158.png)

After:

![image](https://cloud.githubusercontent.com/assets/4240292/18400437/e54049e8-76a3-11e6-8b71-f75ec3a36e4f.png)
