### PR TITLE
Adjusts label height to allow for 2 lines

### DIFF
--- a/scss/_components/_forms/_field-label.scss
+++ b/scss/_components/_forms/_field-label.scss
@@ -23,7 +23,7 @@
   font-size: 16px;
   font-weight: 600;
   margin: 0 0 ($base-spacing / 4);
-  height: 1.5em;
+  max-height: 3em;
   overflow: hidden;
   transition: height 0.5s;
 


### PR DESCRIPTION
Currently on small screens the `.-field-label` gets cut off because it spans 2 lines. 

![image](https://cloud.githubusercontent.com/assets/897368/19314422/11b8873c-9068-11e6-8776-b4ef344fd1e8.png)

This fixes that problem by allowing for a max height rather than a static 1 line. This lets both 1 line & 2 line labels coexist in the form,

<img width="319" alt="screen shot 2016-10-12 at 10 39 29 am" src="https://cloud.githubusercontent.com/assets/897368/19314458/2d2f2b92-9068-11e6-9b2f-a7423d29d100.png">

(and for good measure this is what it looks like on the local forge site)
<img width="895" alt="screen shot 2016-10-12 at 10 39 48 am" src="https://cloud.githubusercontent.com/assets/897368/19314506/5e7bacc0-9068-11e6-86bf-2abeefd4ddde.png">
<img width="903" alt="screen shot 2016-10-12 at 10 40 22 am" src="https://cloud.githubusercontent.com/assets/897368/19314505/5e7381ee-9068-11e6-8272-19dd883f34fa.png">
