### PR TITLE
Allow serving our limited subset of 'node_modules' on GitHub Pages.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -11,6 +11,7 @@ build:
     - script:
         name: build static pattern library
         code: |-
+          touch .nojekyll
           export STYLEGUIDE_PORT=8000
           npm run styleguide &
           sleep 10 # let Node start up!


### PR DESCRIPTION
One tiny little fix to 404ing assets, since [updated Jekyll auto-ignores vendor directories](https://git.io/vNVcu).