### PR TITLE
Make sure '.nojekyll' ends up on 'gh-pages' branch.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -11,11 +11,11 @@ build:
     - script:
         name: build static pattern library
         code: |-
-          touch .nojekyll
           export STYLEGUIDE_PORT=8000
           npm run styleguide &
           sleep 10 # let Node start up!
           wget -mpc --user-agent="" -e robots=off -P build -nH http://localhost:${STYLEGUIDE_PORT}/
+          touch build/.nojekyll
 
 # Automatically deploy `dev` branch to Github pages
 deploy:


### PR DESCRIPTION
Ugh, I haven't touched this in a long time. We output the "static" version of the site into `build/` and then push the contents of that directory to the `gh-pages` branch.