### PR TITLE
Fix compiling CommonJS source for npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist",
     "start": "npm run styleguide & npm run build:dev",
     "styleguide": "NODE_ENV=test babel-node styleguide/app.js",
-    "build": "npm run clean && npm run modernizr && NODE_ENV=production webpack && babel js --out-dir lib",
+    "build": "npm run clean && npm run modernizr && NODE_ENV=production webpack && NODE_ENV=test babel js --out-dir lib",
     "build:dev": "npm run clean && npm run modernizr && webpack",
     "modernizr": "modernizr -c modernizr.json -d dist/modernizr.js",
     "test": "eslint js && sasslint scss/**/*.scss"


### PR DESCRIPTION
I accidentally wasn't packaging the CommonJS-ified version of these modules (which is, [somewhat awkwardly](https://github.com/DoSomething/babel-config/blob/ce5692662ae04caac81451aa6e0736b6c4501853/index.js#L6-L8), set using the `NODE_ENV` environment variable for now).