### PR TITLE
Update fonts and static assets location.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2824,6 +2824,15 @@
         "jquery": "^3.0.0"
       }
     },
+    "dosomething-validation": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/dosomething-validation/-/dosomething-validation-0.2.7.tgz",
+      "integrity": "sha512-T0OQBLD0b6xqS+1/nU8tMN24G1p51dpLFF+gGZ73QanF2pbt3kfmYYL6hsTlRrnwovzAhUQruyOSUK6uo50UNg==",
+      "dev": true,
+      "requires": {
+        "jquery": "^3.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/scss/_base/_fonts.scss
+++ b/scss/_base/_fonts.scss
@@ -1,28 +1,3 @@
-// Proxima Nova
-@font-face {
-  font-family: "Proxima Nova";
-  font-weight: 400;
-  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Regular.eot");
-  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Regular.eot?") format("eot"),
-       url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Regular.woff") format("woff");
-}
-
-@font-face {
-  font-family: "Proxima Nova";
-  font-weight: 600;
-  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-SBold.eot");
-  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-SBold.eot?") format("eot"),
-       url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-SBold.woff") format("woff");
-}
-
-@font-face {
-  font-family: "Proxima Nova";
-  font-weight: 700;
-  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Bold.eot");
-  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Bold.eot?") format("eot"),
-       url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Bold.woff") format("woff");
-}
-
 // Covered By Your Grace
 @font-face {
   font-family: "CoveredGrace";

--- a/scss/_base/_fonts.scss
+++ b/scss/_base/_fonts.scss
@@ -2,35 +2,35 @@
 @font-face {
   font-family: "Proxima Nova";
   font-weight: 400;
-  src: url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-Regular.eot");
-  src: url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-Regular.eot?") format("eot"),
-       url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-Regular.woff") format("woff");
+  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Regular.eot");
+  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Regular.eot?") format("eot"),
+       url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Regular.woff") format("woff");
 }
 
 @font-face {
   font-family: "Proxima Nova";
   font-weight: 600;
-  src: url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-SBold.eot");
-  src: url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-SBold.eot?") format("eot"),
-       url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-SBold.woff") format("woff");
+  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-SBold.eot");
+  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-SBold.eot?") format("eot"),
+       url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-SBold.woff") format("woff");
 }
 
 @font-face {
   font-family: "Proxima Nova";
   font-weight: 700;
-  src: url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-Bold.eot");
-  src: url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-Bold.eot?") format("eot"),
-       url("https://www.dosomething.org/sites/default/files/fonts/proxima-nova/ProximaNova-Bold.woff") format("woff");
+  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Bold.eot");
+  src: url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Bold.eot?") format("eot"),
+       url("https://assets.dosomething.org/us/fonts/proxima-nova/ProximaNova-Bold.woff") format("woff");
 }
 
 // Covered By Your Grace
 @font-face {
   font-family: "CoveredGrace";
-  src: url("https://www.dosomething.org/sites/default/files/fonts/covered-grace/CoveredGrace-Regular.eot");
-  src: url("https://www.dosomething.org/sites/default/files/fonts/covered-grace/CoveredGrace-Regular.eot?#iefix") format("embedded-opentype"),
-       url("https://www.dosomething.org/sites/default/files/fonts/covered-grace/CoveredGrace-Regular.woff") format("woff"),
-       url("https://www.dosomething.org/sites/default/files/fonts/covered-grace/CoveredGrace-Regular.ttf") format("truetype"),
-       url("https://www.dosomething.org/sites/default/files/fonts/covered-grace/CoveredGrace-Regular.svg#covered_by_your_graceregular") format("svg");
+  src: url("https://assets.dosomething.org/us/fonts/covered-grace/CoveredGrace-Regular.eot");
+  src: url("https://assets.dosomething.org/us/fonts/covered-grace/CoveredGrace-Regular.eot?#iefix") format("embedded-opentype"),
+       url("https://assets.dosomething.org/us/fonts/covered-grace/CoveredGrace-Regular.woff") format("woff"),
+       url("https://assets.dosomething.org/us/fonts/covered-grace/CoveredGrace-Regular.ttf") format("truetype"),
+       url("https://assets.dosomething.org/us/fonts/covered-grace/CoveredGrace-Regular.svg#covered_by_your_graceregular") format("svg");
   font-weight: normal;
   font-style: normal;
 }

--- a/scss/_utilities/_variables.scss
+++ b/scss/_utilities/_variables.scss
@@ -63,7 +63,8 @@ $color-tint: 10%;
 // ----------
 
 // Font Stacks
-$font-proxima-nova: "Proxima Nova", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$font-sans-serif: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$font-proxima-nova: $font-sans-serif; // DEPRECATED: Use $font-sans-serif.
 $font-handwritten: "CoveredGrace", cursive;
 
 $base-font-family: $font-proxima-nova;

--- a/styleguide/index.ejs
+++ b/styleguide/index.ejs
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="node_modules/dosomething-modal/dist/modal.css" media="screen, projection" type="text/css">
   <link rel="stylesheet" href="node_modules/dosomething-validation/dist/validation.css" media="screen, projection" type="text/css">
 
+  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro" rel="stylesheet">
   <link rel="stylesheet" href="dist/forge.css" media="screen, projection" type="text/css">
   <link rel="stylesheet" href="dist/styleguide.css" media="screen, projection" type="text/css">
 
@@ -162,18 +163,7 @@
         <%- include('pattern', { pattern: styleguide.sections('Base - Inline Elements') }) %>
 
         <h3 id="fonts-and-colors">Fonts &amp; Colors</h3>
-        <p>We use <a href="http://www.marksimonson.com/fonts/view/proxima-nova">Proxima Nova</a> for all headings and body copy.</p>
-        <p class="font-tile" style="font-family: 'Proxima Nova'; font-weight: 400; ">
-          Any cause, anytime, anywhere. <code>($font-proxima-nova, $weight-normal)</code>
-        </p>
-
-        <p class="font-tile" style="font-family: 'Proxima Nova'; font-weight: 600; ">
-          Any cause, anytime, anywhere. <code>($font-proxima-nova, $weight-sbold)</code>
-        </p>
-
-        <p class="font-tile" style="font-family: 'Proxima Nova'; font-weight: 700; ">
-          Any cause, anytime, anywhere. <code>($font-proxima-nova, $weight-bold)</code>
-        </p>
+        <p>We use <a href="https://fonts.google.com/specimen/Source+Sans+Pro">Source Sans Pro</a> for all headings and body copy.</p>
 
         <p>We use <a href="https://www.google.com/fonts/specimen/Covered+By+Your+Grace">Covered By Your Grace</a> as the "voice" of DoSomething.org.</p>
         <p class="font-tile" style="font-family: 'CoveredGrace';">


### PR DESCRIPTION
This pull request updates the path where we host static assets (for fan-favorite Covered By Your Grace) now that Drupal is heading out, and removes Proxima Nova from our base stylesheet in favor of the new hotness, [Source Sans Pro](https://fonts.google.com/specimen/Source+Sans+Pro).

References [#165498230](https://www.pivotaltracker.com/story/show/165498230).