### PR TITLE
changes footnote p to #757575

### DIFF
--- a/scss/_components/_footnote.scss
+++ b/scss/_components/_footnote.scss
@@ -22,7 +22,7 @@
 
   p {
     font-size: $font-small;
-    color: $med-gray;
+    color: #757575;
     margin: 0;
   }
 

--- a/scss/_components/_footnote.scss
+++ b/scss/_components/_footnote.scss
@@ -16,18 +16,20 @@
 //   </div>
 //
 // Styleguide Footnote
+$footnote-gray: #757575;
+
 .footnote {
   font-size: $font-small;
-  color: $med-gray;
+  color: $footnote-gray;
 
   p {
     font-size: $font-small;
-    color: #757575;
+    color: $footnote-gray;
     margin: 0;
   }
 
   .heading, h1, h2, h3, h4, h5, h6 {
-    color: $med-gray;
+    color: $footnote-gray;
   }
 
   sup {
@@ -49,7 +51,7 @@
   }
 
   a {
-    color: $med-gray;
+    color: $footnote-gray;
     text-decoration: underline;
 
     &:hover {


### PR DESCRIPTION
This PR changes `footnote` `p` to `#757575` to make messaging opt-in text more prominent on registration form.

[Pivotal Ticket](https://www.pivotaltracker.com/n/projects/2328687/stories/166290439)